### PR TITLE
Feature/add django memoize

### DIFF
--- a/mpbackend/settings.py
+++ b/mpbackend/settings.py
@@ -60,6 +60,7 @@ INSTALLED_APPS = [
     "drf_spectacular",
     "corsheaders",
     "django_filters",
+    "memoize",
 ]
 
 MIDDLEWARE = [

--- a/profiles/tests/api/test_answer.py
+++ b/profiles/tests/api/test_answer.py
@@ -4,6 +4,7 @@ from rest_framework.reverse import reverse
 
 from account.models import User
 from profiles.models import Answer, Option, Question, SubQuestion
+from profiles.tests.utils import delete_memoized_functions_cache
 
 
 def test_answer_post_unauthenticated(api_client):
@@ -22,6 +23,7 @@ def test_poll_start(api_client):
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_post_answer(api_client_authenticated, users, questions, options):
     user = users.get(username="test1")
     assert Answer.objects.count() == 0
@@ -38,6 +40,7 @@ def test_post_answer(api_client_authenticated, users, questions, options):
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_post_answer_with_other_option(api_client, users, answers, questions, options):
     user = users.get(username="no answers user")
     token = Token.objects.create(user=user)
@@ -63,6 +66,7 @@ def test_post_answer_with_other_option(api_client, users, answers, questions, op
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_post_answer_answer_is_updated(
     api_client_authenticated, users, answers, questions, options
 ):
@@ -125,6 +129,7 @@ def test_post_answer_where_question_not_related_to_option(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_answer_get_result(api_client_authenticated, users, answers):
     url = reverse("profiles:answer-get-result")
     response = api_client_authenticated.get(url)
@@ -133,6 +138,7 @@ def test_answer_get_result(api_client_authenticated, users, answers):
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_post_answer_where_condition_not_met(
     api_client,
     users,
@@ -157,6 +163,7 @@ def test_post_answer_where_condition_not_met(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_post_answer_where_condition_is_met(
     api_client,
     users,

--- a/profiles/tests/api/test_postal_code_result.py
+++ b/profiles/tests/api/test_postal_code_result.py
@@ -10,9 +10,11 @@ from profiles.models import (
     PostalCodeType,
     SubQuestion,
 )
+from profiles.tests.utils import delete_memoized_functions_cache
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_postal_code_result(api_client, questions, sub_questions, options, results):
     num_users = 21
     num_answers = 0

--- a/profiles/tests/api/test_question.py
+++ b/profiles/tests/api/test_question.py
@@ -7,9 +7,9 @@ from rest_framework.authtoken.models import Token
 from rest_framework.reverse import reverse
 
 from profiles.models import Answer, PostalCodeResult
+from profiles.tests.utils import delete_memoized_functions_cache
 
 
-@pytest.mark.django_db
 @pytest.mark.django_db
 def test_sub_questions_conditions_states(
     api_client,
@@ -44,6 +44,7 @@ def test_questions_condition_states_not_authenticated(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_questions_condition_states_after_post_answer(
     api_client, users, questions, question_conditions, options
 ):
@@ -76,6 +77,7 @@ def test_questions_condition_states_after_post_answer(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_questions_condition_states(
     api_client, users, answers, questions, question_conditions
 ):
@@ -117,6 +119,7 @@ def test_questions_condition_states(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_get_questions_with_conditions(
     api_client, users, answers, questions, question_conditions
 ):
@@ -129,6 +132,7 @@ def test_get_questions_with_conditions(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_question_condition_is_met(
     api_client, users, answers, questions, question_conditions
 ):
@@ -144,6 +148,7 @@ def test_question_condition_is_met(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_question_condition_not_met(
     api_client, users, answers, questions, question_conditions
 ):
@@ -181,6 +186,7 @@ def test_question_with_sub_question_condition_is_met(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_question_with_sub_question_condition_not_met(
     api_client,
     users,
@@ -362,9 +368,7 @@ def test_result_count_is_filled_for_fun_is_false(
 
 
 @pytest.mark.django_db
-def test_result_count_is_filled_for_fun_is_true(
-    api_client_authenticated, answers, users
-):
+def test_result_count_is_filled_for_fun_is_true(api_client_authenticated, users):
     user = users.get(username="test1")
     url = reverse("profiles:question-end-poll")
     user.profile.is_filled_for_fun = True
@@ -375,8 +379,9 @@ def test_result_count_is_filled_for_fun_is_true(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_result_count_result_can_be_used_is_true(
-    api_client_authenticated, answers, users
+    api_client_authenticated, users, answers
 ):
     user = users.get(username="test1")
     assert user.profile.result_can_be_used is True
@@ -387,8 +392,9 @@ def test_result_count_result_can_be_used_is_true(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_result_count_result_can_be_used_is_false(
-    api_client_authenticated, answers, users
+    api_client_authenticated, users, answers
 ):
     user = users.get(username="test1")
     user.profile.result_can_be_used = False
@@ -400,6 +406,7 @@ def test_result_count_result_can_be_used_is_false(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_sub_question_condition(
     api_client_authenticated, questions, sub_question_conditions, options, sub_questions
 ):

--- a/profiles/tests/api/test_result.py
+++ b/profiles/tests/api/test_result.py
@@ -2,6 +2,7 @@ import pytest
 from rest_framework.reverse import reverse
 
 from profiles.tests.conftest import NEG, OK, POS, YES_BIKE
+from profiles.tests.utils import delete_memoized_functions_cache
 
 ANSWER_URL = reverse("profiles:answer-list")
 RESULT_URL = reverse("profiles:answer-get-result")
@@ -14,6 +15,7 @@ def test_result_no_answers(api_client_auth_no_answers):
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_relative_result(
     api_client_auth_no_answers,
     questions_test_result,
@@ -38,6 +40,7 @@ def test_relative_result(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_neg_result(
     api_client_auth_no_answers,
     questions_test_result,
@@ -66,6 +69,7 @@ def test_neg_result(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_ok_result(
     api_client_auth_no_answers,
     questions_test_result,
@@ -96,6 +100,7 @@ def test_ok_result(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_pos_result(
     api_client_auth_no_answers,
     questions_test_result,
@@ -112,6 +117,7 @@ def test_pos_result(
 
 
 @pytest.mark.django_db
+@delete_memoized_functions_cache
 def test_options_with_multiple_results(
     api_client_auth_no_answers,
     questions_test_result,

--- a/profiles/tests/utils.py
+++ b/profiles/tests/utils.py
@@ -1,0 +1,10 @@
+from memoize import delete_memoized
+
+from profiles.utils import get_num_results_per_option
+
+
+def delete_memoized_functions_cache(func):
+    def wrapper():
+        delete_memoized(get_num_results_per_option)
+
+    return wrapper

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -3,8 +3,9 @@ import string
 
 from account.models import User
 from profiles.models import Answer, Option, Result
+from memoize import memoize
 
-
+@memoize(timeout=60*60)
 def get_num_results_per_option() -> dict:
     results = {}
     for result in Result.objects.all():
@@ -29,6 +30,7 @@ def get_user_result(user: User) -> Result:
         return None
     # calculate the relative result for every result (animal)
     results = {}
+
     for result in Result.objects.all():
         results[result] = cum_results[result] / num_results_in_option[result]
 

--- a/profiles/utils.py
+++ b/profiles/utils.py
@@ -1,11 +1,13 @@
 import secrets
 import string
 
-from account.models import User
-from profiles.models import Answer, Option, Result
 from memoize import memoize
 
-@memoize(timeout=60*60)
+from account.models import User
+from profiles.models import Answer, Option, Result
+
+
+@memoize(timeout=60 * 60)
 def get_num_results_per_option() -> dict:
     results = {}
     for result in Result.objects.all():

--- a/requirements.in
+++ b/requirements.in
@@ -17,3 +17,4 @@ django-cors-headers
 freezegun
 django-filter
 pymemcache
+django-memoize

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ django==4.2
     #   django-cors-headers
     #   django-extensions
     #   django-filter
+    #   django-memoize
     #   django-modeltranslation
     #   djangorestframework
     #   drf-spectacular
@@ -34,6 +35,8 @@ django-environ==0.10.0
 django-extensions==3.2.1
     # via -r requirements.in
 django-filter==23.5
+    # via -r requirements.in
+django-memoize==2.3.1
     # via -r requirements.in
 django-modeltranslation==0.18.9
     # via -r requirements.in


### PR DESCRIPTION
# Feature/add django memoize
### Trello #73

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
1. mpbackend/settings.py
    * Add memoize to INSTALLED_APPIS
2. profiles/tests/api/test_answer.py
3. profiles/tests/api/test_postal_code_result.py
4. profiles/tests/api/test_question.py
5. profiles/tests/api/test_result.py
    * Add delete_memoized_function_cache decorator to tests that requires it
6. profiles/tests/utils.py
    * Add decorator function that deletes the memoized functions cache
7. profiles/utils.py
    * Add memoize to get_num_results_per_option function
8. requirements.in
9. requirements.in
    * Add django-memoize