### PR TITLE
Feature/postal code result blur count

### DIFF
--- a/profiles/api/serializers.py
+++ b/profiles/api/serializers.py
@@ -13,6 +13,8 @@ from profiles.models import (
     SubQuestionCondition,
 )
 
+from .utils import blur_count
+
 
 class ResultSerializer(serializers.ModelSerializer):
     class Meta:
@@ -130,6 +132,11 @@ class PostalCodeResultSerializer(serializers.ModelSerializer):
             "result_topic_en",
             "count",
         ]
+
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+        representation["count"] = blur_count(instance.count)
+        return representation
 
 
 class PostalCodeSerializer(serializers.ModelSerializer):

--- a/profiles/api/utils.py
+++ b/profiles/api/utils.py
@@ -4,6 +4,17 @@ from rest_framework.exceptions import ValidationError
 from profiles.models import PostalCodeResult
 
 
+def blur_count(count, threshold=5):
+    """
+    Returns a blurred count, which is supposed to hide individual
+    postal code results.
+    """
+    if count <= threshold:
+        return 0
+    else:
+        return count
+
+
 class CustomValidationError(ValidationError):
     # The detail field is shown also when DEBUG=False
     # Ensures the error message is displayed to the user

--- a/profiles/tests/api/test_postal_code_result.py
+++ b/profiles/tests/api/test_postal_code_result.py
@@ -11,6 +11,21 @@ ANSWER_URL = reverse("profiles:answer-list")
 
 
 @pytest.mark.django_db
+def test_blur_count(api_client, results):
+    postal_code_result = PostalCodeResult.objects.create(
+        count=5, result=results.first()
+    )
+    url = reverse("profiles:postalcoderesult-detail", args=[str(postal_code_result.id)])
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
+    postal_code_result.count = 6
+    postal_code_result.save()
+    response = api_client.get(url)
+    assert response.json()["count"] == 6
+
+
+@pytest.mark.django_db
 def test_postal_code_result_with_postal_code_and_optional_postal_code(
     api_client, users, questions, options, results
 ):


### PR DESCRIPTION
# Blur PostalCodeResult count
## Description
Trello #87
-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
1. profiles/api/serializers.py
    * Blur PostalCodeResult count
2. profiles/api/utils.py
    * Add blur_count function
3. profiles/tests/api/test_postal_code_result.py
    * Test blur count