### PR TITLE
Feature/start poll add throttling

### DIFF
--- a/account/tests/test_api.py
+++ b/account/tests/test_api.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework.reverse import reverse
 
+from account.api.views import ProfileViewSet
 from account.models import MailingList, MailingListEmail, User
 from profiles.models import PostalCode, PostalCodeResult
 
@@ -48,7 +49,10 @@ def test_unauthenticated_cannot_do_anything(api_client, users):
 def test_mailing_list_unsubscribe_throttling(
     api_client_with_custom_ip_address, mailing_list_emails
 ):
-    num_requests = 10
+    # Set number of requests to be made from the rate. The rate is stored as a string, e.g., rate = "10/day"
+    num_requests = int(
+        ProfileViewSet.unsubscribe.kwargs["throttle_classes"][0].rate.split("/")[0]
+    )
     url = reverse("account:profiles-unsubscribe")
     count = 0
     while count < num_requests:

--- a/profiles/api/utils.py
+++ b/profiles/api/utils.py
@@ -1,5 +1,6 @@
 import django_filters
 from rest_framework.exceptions import ValidationError
+from rest_framework.throttling import AnonRateThrottle
 
 from profiles.models import PostalCodeResult
 
@@ -13,6 +14,15 @@ def blur_count(count, threshold=5):
         return 0
     else:
         return count
+
+
+class StartPollRateThrottle(AnonRateThrottle):
+    """
+    The AnonRateThrottle will only ever throttle unauthenticated users.
+    The IP address of the incoming request is used to generate a unique key to throttle against.
+    """
+
+    rate = "10/day"
 
 
 class CustomValidationError(ValidationError):

--- a/profiles/api/views.py
+++ b/profiles/api/views.py
@@ -56,7 +56,7 @@ from profiles.models import (
 )
 from profiles.utils import encrypt_text, generate_password, get_user_result
 
-from .utils import PostalCodeResultFilter
+from .utils import PostalCodeResultFilter, StartPollRateThrottle
 
 logger = logging.getLogger(__name__)
 
@@ -185,6 +185,7 @@ class QuestionViewSet(viewsets.ReadOnlyModelViewSet):
         detail=False,
         methods=["POST"],
         permission_classes=[AllowAny],
+        throttle_classes=[StartPollRateThrottle],
     )
     def start_poll(self, request):
         uuid4 = uuid.uuid4()


### PR DESCRIPTION
# Add throttling to start poll
## Trello #86
-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
1. account/tests/test_api.py
    * Read num_request from the defined rate
2. profiles/api/utils.py
    * Add class StartPollRateThrottle
3. profiles/api/views.py
    * Add StartPollRateThrottle to start_poll throttle_classes
4. profiles/tests/api/test_answer.py
    * Add throttling test for start_poll