### PR TITLE
Feature/cumulative results blur count

### DIFF
--- a/profiles/api/serializers.py
+++ b/profiles/api/serializers.py
@@ -160,7 +160,7 @@ class CumulativeResultSerializer(serializers.ModelSerializer):
     def to_representation(self, instance):
         type_name = self.context.get("type_name")
         representation = super().to_representation(instance)
-        representation["sum_of_count"] = instance.get_sum_of_count(
-            postal_code_type_name=type_name
+        representation["sum_of_count"] = blur_count(
+            instance.get_sum_of_count(postal_code_type_name=type_name)
         )
         return representation

--- a/profiles/api/utils.py
+++ b/profiles/api/utils.py
@@ -10,7 +10,8 @@ def blur_count(count, threshold=5):
     Returns a blurred count, which is supposed to hide individual
     postal code results.
     """
-    if count <= threshold:
+
+    if not count or count <= threshold:
         return 0
     else:
         return count

--- a/profiles/tests/api/test_postal_code_result.py
+++ b/profiles/tests/api/test_postal_code_result.py
@@ -317,3 +317,5 @@ def test_cumulative_results(
     json_data = response.json()
     assert json_data["count"] == results.count()
     assert json_data["results"][0]["sum_of_count"] == 6
+    # Test that count is blurred
+    assert json_data["results"][1]["sum_of_count"] == 0

--- a/profiles/tests/conftest.py
+++ b/profiles/tests/conftest.py
@@ -81,6 +81,12 @@ def postal_code_results(postal_codes, postal_code_types, results):
         result=results.first(),
         count=2,
     )
+    PostalCodeResult.objects.create(
+        postal_code=postal_codes.last(),
+        postal_code_type=postal_code_types.first(),
+        result=results.last(),
+        count=0,
+    )
     return PostalCodeResult.objects.all()
 
 


### PR DESCRIPTION
# Blur cumulative results count
## Description
Trello #112

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Files changed
1. profiles/api/serializers.py
    * Blur count for cumulative results
2. profiles/api/utils.py
    * Handle None in blur_count function
3. profiles/tests/api/test_postal_code_result.py
    * Test that cumulative result count is blurred
4. profiles/tests/conftest.py
    * Add PostalCodeResult fixture